### PR TITLE
leave-maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,5 @@ about:
 extra:
   recipe-maintainers:
     - ivoflipse
-    - Korijn
     - Maxyme
     - EelcoHoogendoorn


### PR DESCRIPTION
I no longer wish to maintain conda packages, so I'm editing myself out of the maintainers in the recipes.